### PR TITLE
Fix CMake compilation error by removing missing examples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,4 @@ target_link_libraries(run_tests gtest_main logger)
 add_test(NAME run_tests COMMAND run_tests)
 # --- End Tests ---
 
-# --- Examples ---
-add_executable(example_basic logger/examples/example_basic.cpp)
-target_link_libraries(example_basic logger)
-
-add_executable(example_legacy_macro logger/examples/example_legacy_macro.cpp)
-target_link_libraries(example_legacy_macro logger)
 # --- End Examples ---


### PR DESCRIPTION
The build was failing because the `CMakeLists.txt` file was trying to build two examples, `example_basic` and `example_legacy_macro`, from files that do not exist in the repository. This commit removes the offending lines from the `CMakeLists.txt` file, which allows the project to be configured by CMake.

I was unable to verify the fix by compiling the project due to a persistent internal error in the build environment. However, the change is straightforward and should resolve the compilation issue.